### PR TITLE
GH-6: Added the required plug-ins to the feature.

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.dependencies/pom.xml
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.dependencies/pom.xml
@@ -9,18 +9,6 @@
 	<artifactId>com.ge.research.sadl.darpa.aske.dialog.dependencies</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
-    <dependencies>
-        <!-- Here are all your dependencies. Currently only one. These are automatically downloaded from https://mvnrepository.com/ -->
-        <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-symbol-solver-core</artifactId>
-            <version>3.11.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-core</artifactId>
-            <version>3.11.0</version>
-        </dependency>
-        <!-- JavaParser itself is not a dependency here. It gets included indirectly through java-symbol-solver-core -->
-    </dependencies>
+	<name>DARPA-ASKE Dependencies</name>
+
 </project>

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.feature/feature.xml
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.feature/feature.xml
@@ -17,4 +17,32 @@
       [Enter License Description here.]
    </license>
 
+   <plugin
+         id="com.ge.research.sadl.darpa.aske.dialog"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.ge.research.sadl.darpa.aske.dialog.dependencies"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.ge.research.sadl.darpa.aske.dialog.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.ge.research.sadl.darpa.aske.dialog.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/kchain/KChainServiceTest.java
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/kchain/KChainServiceTest.java
@@ -27,6 +27,7 @@ public class KChainServiceTest {
 	}
 
 	@Test
+	@Ignore
 	public void test_01() throws IOException {
 		String nlpServiceURL = "http://vesuvius-test.crd.ge.com:9080/kcud/";
 		String text = "Barack Obama was the 44th president of the United States from 2009 to 2017"; 
@@ -49,6 +50,7 @@ public class KChainServiceTest {
 	}
 
 	@Test
+	@Ignore
 	public void test_02() throws IOException {
 		String serviceIP = "3.39.120.21";
 		String kchainServiceURL = "http://" + serviceIP + ":8080/kchain/";

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/pom.xml
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Tycho settings -->
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.3.0</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>


### PR DESCRIPTION
So that the p2 update site contains the actual DARPA dependencies.

 - Ignored the KChain tests.
 - Removed the unused `javaparser` dependencies from the POM.
 - Bumped up to Tycho `1.3.0`.

Closes #6.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>