### PR TITLE
GH-10: Added `Cg` as a Jena Builtin.

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/META-INF/services/com.hp.hpl.jena.reasoner.rulesys.Builtin
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/META-INF/services/com.hp.hpl.jena.reasoner.rulesys.Builtin
@@ -1,0 +1,1 @@
+com.ge.research.sadl.darpa.aske.inference.builtin.Cg


### PR DESCRIPTION
Note: the `Cg` class is visible only from one of the DARPA projects.

```
println(' >> Builtin classes discovered by the service loader:')
ServiceLoader.load(Builtin).forEach[
  println(class.name);
];
println(' << End of Builtin classes.')
```

Closes #10.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----
**Note:** Running the above code will print `com.ge.research.sadl.darpa.aske.inference.builtin.Cg` only.