### PR TITLE
Various fixes for the demo.

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ide/src/com/ge/research/sadl/darpa/aske/ide/DialogIdeModule.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ide/src/com/ge/research/sadl/darpa/aske/ide/DialogIdeModule.xtend
@@ -3,16 +3,9 @@
  */
 package com.ge.research.sadl.darpa.aske.ide
 
-import com.ge.research.sadl.utils.SadlProjectHelper
-import com.ge.research.sadl.ide.utils.SadlIdeProjectHelper
-
 /**
  * Use this class to register ide components.
  */
 class DialogIdeModule extends AbstractDialogIdeModule {
-
-	def Class<? extends SadlProjectHelper> bindSadlProjectHelper() {
-		return SadlIdeProjectHelper;
-	}
 
 }

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui/src/com/ge/research/sadl/darpa/aske/ui/DialogUiModule.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui/src/com/ge/research/sadl/darpa/aske/ui/DialogUiModule.xtend
@@ -5,16 +5,13 @@ package com.ge.research.sadl.darpa.aske.ui
 
 import com.ge.research.sadl.darpa.aske.ui.answer.DialogAnswerProvider
 import com.ge.research.sadl.darpa.aske.ui.contentassist.DialogOntologyContextProvider
+import com.ge.research.sadl.darpa.aske.ui.preferences.DialogPreferencesInitializer
 import com.ge.research.sadl.darpa.aske.ui.preferences.DialogRootPreferencePage
 import com.ge.research.sadl.darpa.aske.ui.syntaxcoloring.DialogHighlightingConfiguration
 import com.ge.research.sadl.darpa.aske.ui.syntaxcoloring.DialogSemanticHighlightingCalculator
 import com.ge.research.sadl.darpa.aske.ui.syntaxcoloring.DialogTokenToAttributeIdMapper
-import com.ge.research.sadl.external.ExternalEmfResourcePredicate
 import com.ge.research.sadl.ide.editor.contentassist.IOntologyContextProvider
 import com.ge.research.sadl.ui.contentassist.SadlReferenceProposalCreator
-import com.ge.research.sadl.ui.external.EclipseExternalEmfResourcePredicate
-import com.ge.research.sadl.ui.utils.EclipseSadlProjectHelper
-import com.ge.research.sadl.utils.SadlProjectHelper
 import com.google.inject.Binder
 import com.google.inject.name.Names
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
@@ -25,7 +22,6 @@ import org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposa
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer
 import org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
-import com.ge.research.sadl.darpa.aske.ui.preferences.DialogPreferencesInitializer
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.
@@ -47,18 +43,10 @@ class DialogUiModule extends AbstractDialogUiModule {
 		return DialogTokenToAttributeIdMapper
 	}
 	
-	def Class<? extends ExternalEmfResourcePredicate> bindExternalEmfResourcePredicate() {
-		return EclipseExternalEmfResourcePredicate;
-	}
-	
 	def Class<? extends DefaultAutoEditStrategyProvider> bindDefaultAutoEditStrategyProvider() {
 		return DialogAnswerProvider
 	}
 
-	def Class<? extends SadlProjectHelper> bindSadlProjectHelper() {
-		return EclipseSadlProjectHelper;
-	}
-	
 	def void configurePreferenceInitializer(Binder binder) {
 		binder.bind(IPreferenceStoreInitializer).annotatedWith(Names.named("dialogPreferenceInitializer")).to(
 			DialogPreferencesInitializer)


### PR DESCRIPTION
 - Do not refresh the project, but build it after the extraction of the
.sadl|.owl file.
 - Do not try to access the resource via reflection, use `UnitOfWork`.
 - Fixed the `CodeExtractionModel.sadl` creation. Triggered a build.
 - Got rid of the standlone setup call, and use the hard-coded list of
SADL keywords.
 - Updated the Dialog UI module bindings.


Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

@crapo, please try this out. I had to apply various interim workarounds. It should work for the demo, in Eclipse but nothing more is supported this time. Also, please do **not** change the grammar anymore. The SADL keywords is a shared hard-coded list now. See here: https://github.com/crapo/sadlos2/commit/72387abaa8c6720725a162ec7f44e62e09732d31