### PR TITLE
GH-18: Added the `dialog` extension filter to the inference processor.

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/inference/JenaBasedDialogInferenceProcessor.java
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/inference/JenaBasedDialogInferenceProcessor.java
@@ -318,9 +318,12 @@ public class JenaBasedDialogInferenceProcessor extends JenaBasedSadlInferencePro
 			"  ?Oinst imp:stddev ?StdDev.\n" +
 			//"  ?SG mm:cgraph/sci:hasEquation/imp:expression ?EQ.\n" + 
 			"}";
-	
-	
-	
+
+	@Override
+	public boolean isSupported(String fileExtension) {
+		return "dialog".equals(fileExtension);
+	}
+
 	@Override
 	public Object[] insertTriplesAndQuery(Resource resource, TripleElement[] triples) throws SadlInferenceException {
 		setCurrentResource(resource);


### PR DESCRIPTION
Upstream:
https://github.com/crapo/sadlos2/pull/368/commits/58de47083ecb58e82eb3f962f2e91efe70ccf7af

Closes #18.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>