### PR TITLE
Dialog test

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/AbstractDialogTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/AbstractDialogTest.xtend
@@ -13,10 +13,18 @@ import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.validation.Issue
 import org.junit.runner.RunWith
+import org.junit.Before
+import com.ge.research.sadl.SADLStandaloneSetup
 
 @RunWith(XtextRunner)
 @InjectWith(DialogInjectorProvider)
 abstract class AbstractDialogTest extends AbstractSadlTest {
+	
+	@Before
+	override initialize() {
+		SADLStandaloneSetup.doSetup
+		super.initialize()
+	}
 
 	protected def XtextResource dialog(CharSequence seq) {
 		return resource(seq, 'dialog') as XtextResource;

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogTest.xtend
@@ -7,231 +7,188 @@ import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
 
 class DialogTest extends AbstractDialogTest {
-	
+
 	@Test
 	def void dummy_test() {
 		'''
-			uri  "http://sadl.org/Test.sadl" alias Test.
+			uri "http://sadl.org/Model.sadl" alias mdl.
 			
-			Rock is
+			Mass is a type of UnittedQuantity, 
+				described by force with values of type Force,
+				described by speed with values of type Speed,
+				described by acceleration with values of type Acceleration.
 			
-			Person is a class described by age with values of type int.
-			ChildrenList is a type of Person List length 1-*.
-			children describes Person with values of type ChildrenList.
-			children of Person has at most 1 value.
+			Force is a type of UnittedQuantity.
+			Speed is a type of UnittedQuantity.
+			Acceleration is a type of UnittedQuantity.
 			
-			PersonList is a type of Person List.
-			PersonListList is a type of PersonList List.
-			
-			foo describes Person with values of type PersonListList.
-			bar describes Person with values of type Person List length 1-4.
-			bar of Person only has values of type Person List.
-			bar of Person only has values of type Person List length 1-4.
-			bar of Person has at least one value of type Person List length 1-4.
-			bar of Person has at least 1 value of type Person List length 1-4.
-			bar of Person has at most 2 value of type Person List length 1-4.
-			
-			
-			Rule R1: if x is a Person and
-					x has bar y and 
-					y is a Person List //length 1-4
-					z is a Person List length 1-4
-			then print("Hurray!"). //x has age 50.
+			External secondLaw(double m, double acc) returns double: "http://sadl.org/secondlaw".
 		'''.sadl
-		
+
 		'''
-		uri "http://baseUri".
-		import "http://sadl.org/SpeedOfSound.sadl".
-		
-		
-		CM: "Parsing code file 'C:/Users/200005201/sadl3-master6/git/DARPA-ASKE-TA1/Ontology/M5/ExtractedModels/Sources/Mach.java'".
-		CM: "The following methods doing computation were found in the extraction:".
-		CM: External Mach.CAL_TT(double T, double M, double G, double Q) returns double: "http://com.ge.research.sadl.darpa.aske.answer/Mach_java#Mach.CAL_TT".
-		
-		CM: Mach.CAL_TT has expression (a Script with language Java, with script 
-		"public double CAL_TT(double T, double M, double G, double Q) {
-		    double TT = T / TQTT(M, G);
-		    double EPS = 0.00001;
-		    double Z = 1;
-		    double Z2 = 0;
-		    double TT2 = 0;
-		    double TT1;
-		    double Z1;
-		    double i = 1;
-		    while (Math.abs(Z) > EPS) {
-		        Z = Math.pow(M, 2) - 2 * TT / CAL_GAM(T, G, Q) / T * (G / (G - 1) * (1 - T / TT) + Q / TT * (1 / (Math.exp(Q / TT) - 1) - 1 / (Math.exp(Q / T) - 1)));
-		        if (i == 1) {
-		            Z2 = Z;
-		            TT2 = TT;
-		            TT = TT2 + 100;
-		            i = 2;
-		        } else {
-		            TT1 = TT2;
-		            Z1 = Z2;
-		            TT2 = TT;
-		            Z2 = Z;
-		            TT = TT2 - Z2 * (TT2 - TT1) / (Z2 - Z1);
-		        }
-		    }
-		    if (M <= .1)
-		        TT = T / TQTT(M, G);
-		    return TT;
-		}"
-		), has expression (a Script with language Python, with script 
-		"#!/usr/bin/env python
-		\"\"\" generated source for module inputfile \"\"\"
-		class Mach(object):
-		    \"\"\" generated source for class Mach \"\"\"
-		    def CAL_TT(self, T, M, G, Q):
-		        \"\"\" generated source for method CAL_TT \"\"\"
-		        TT = T / TQTT(M, G)
-		        EPS = 0.00001
-		        Z = 1
-		        Z2 = 0
-		        TT2 = 0
-		        TT1 = float()
-		        Z1 = float()
-		        i = 1
-		        while Math.abs(Z) > EPS:
-		            Z = Math.pow(M, 2) - 2 * TT / CAL_GAM(T, G, Q) / T * (G / (G - 1) * (1 - T / TT) + Q / TT * (1 / (Math.exp(Q / TT) - 1) - 1 / (Math.exp(Q / T) - 1)))
-		            if i == 1:
-		                Z2 = Z
-		                TT2 = TT
-		                TT = TT2 + 100
-		                i = 2
-		            else:
-		                TT1 = TT2
-		                Z1 = Z2
-		                TT2 = TT
-		                Z2 = Z
-		                TT = TT2 - Z2 * (TT2 - TT1) / (Z2 - Z1)
-		        if M <= 0.1:
-		            TT = T / TQTT(M, G)
-		        return TT
-		
-		").
-		CM: External Mach.CAL_SOS(double T, double G, double R, double Q) returns double: "http://com.ge.research.sadl.darpa.aske.answer/Mach_java#Mach.CAL_SOS".
-		
-		CM: Mach.CAL_SOS has expression (a Script with language Java, with script 
-		"public double CAL_SOS(double T, double G, double R, double Q) {
-		    double WOW = 1 + (G - 1) / (1 + (G - 1) * Math.pow((Q / T), 2) * Math.exp(Q / T) / Math.pow((Math.exp(Q / T) - 1), 2));
-		    return (Math.sqrt(32.174 * T * R * WOW));
-		}"
-		), has expression (a Script with language Python, with script 
-		"#!/usr/bin/env python
-		\"\"\" generated source for module inputfile \"\"\"
-		class Mach(object):
-		    \"\"\" generated source for class Mach \"\"\"
-		    def CAL_SOS(self, T, G, R, Q):
-		        \"\"\" generated source for method CAL_SOS \"\"\"
-		        WOW = 1 + (G - 1) / (1 + (G - 1) * Math.pow((Q / T), 2) * Math.exp(Q / T) / Math.pow((Math.exp(Q / T) - 1), 2))
-		        return (Math.sqrt(32.174 * T * R * WOW))
-		
-		").
-		CM: External Mach.CAL_T(double TT, double M, double G, double Q) returns double: "http://com.ge.research.sadl.darpa.aske.answer/Mach_java#Mach.CAL_T".
-		
-		CM: Mach.CAL_T has expression (a Script with language Java, with script 
-		"double CAL_T(double TT, double M, double G, double Q) {
-		    double T = TT * TQTT(M, G);
-		    double EPS = 0.00001;
-		    double Z = 1;
-		    double Z2 = 0;
-		    double T2 = 0;
-		    double T1;
-		    double Z1;
-		    double i = 1;
-		    while (Math.abs(Z) > EPS) {
-		        Z = Math.pow(M, 2) - 2 * TT / CAL_GAM(T, G, Q) / T * (G / (G - 1) * (1 - T / TT) + Q / TT * (1 / (Math.exp(Q / TT) - 1) - 1 / (Math.exp(Q / T) - 1)));
-		        if (i == 1) {
-		            Z2 = Z;
-		            T2 = T;
-		            T = T2 + 100;
-		            i = 2;
-		        } else {
-		            T1 = T2;
-		            Z1 = Z2;
-		            T2 = T;
-		            Z2 = Z;
-		            T = T2 - Z2 * (T2 - T1) / (Z2 - Z1);
-		        }
-		    }
-		    if (M <= .1)
-		        T = TT * TQTT(M, G);
-		    return T;
-		}"
-		), has expression (a Script with language Python, with script 
-		"#!/usr/bin/env python
-		\"\"\" generated source for module inputfile \"\"\"
-		class Mach(object):
-		    \"\"\" generated source for class Mach \"\"\"
-		    def CAL_T(self, TT, M, G, Q):
-		        \"\"\" generated source for method CAL_T \"\"\"
-		        T = TT * TQTT(M, G)
-		        EPS = 0.00001
-		        Z = 1
-		        Z2 = 0
-		        T2 = 0
-		        T1 = float()
-		        Z1 = float()
-		        i = 1
-		        while Math.abs(Z) > EPS:
-		            Z = Math.pow(M, 2) - 2 * TT / CAL_GAM(T, G, Q) / T * (G / (G - 1) * (1 - T / TT) + Q / TT * (1 / (Math.exp(Q / TT) - 1) - 1 / (Math.exp(Q / T) - 1)))
-		            if i == 1:
-		                Z2 = Z
-		                T2 = T
-		                T = T2 + 100
-		                i = 2
-		            else:
-		                T1 = T2
-		                Z1 = Z2
-		                T2 = T
-		                Z2 = Z
-		                T = T2 - Z2 * (T2 - T1) / (Z2 - Z1)
-		        if M <= 0.1:
-		            T = TT * TQTT(M, G)
-		        return T
-		
-		").
-		CM: External Mach.CAL_GAM(double T, double G, double Q) returns double: "http://com.ge.research.sadl.darpa.aske.answer/Mach_java#Mach.CAL_GAM".
-		
-		CM: Mach.CAL_GAM has expression (a Script with language Java, with script 
-		"public double CAL_GAM(double T, double G, double Q) {
-		    return (1 + (G - 1) / (1 + (G - 1) * (Math.pow((Q / T), 2) * Math.exp(Q / T) / Math.pow((Math.exp(Q / T) - 1), 2))));
-		}"
-		), has expression (a Script with language Python, with script 
-		"#!/usr/bin/env python
-		\"\"\" generated source for module inputfile \"\"\"
-		class Mach(object):
-		    \"\"\" generated source for class Mach \"\"\"
-		    def CAL_GAM(self, T, G, Q):
-		        \"\"\" generated source for method CAL_GAM \"\"\"
-		        return (1 + (G - 1) / (1 + (G - 1) * (Math.pow((Q / T), 2) * Math.exp(Q / T) / Math.pow((Math.exp(Q / T) - 1), 2))))
-		
-		").
-		CM: External Mach.TQTT(double M, double G) returns double: "http://com.ge.research.sadl.darpa.aske.answer/Mach_java#Mach.TQTT".
-		
-		CM: Mach.TQTT has expression (a Script with language Java, with script 
-		"public double TQTT(double M, double G) {
-		    return Math.pow((1 + (G - 1) / 2 * Math.pow(M, 2)), -1);
-		}"
-		), has expression (a Script with language Python, with script 
-		"#!/usr/bin/env python
-		\"\"\" generated source for module inputfile \"\"\"
-		class Mach(object):
-		    \"\"\" generated source for class Mach \"\"\"
-		    def TQTT(self, M, G):
-		        \"\"\" generated source for method TQTT \"\"\"
-		        return Math.pow((1 + (G - 1) / 2 * Math.pow(M, 2)), -1)
-		
-		").
-		CM: "Would you like to save the extracted model (Mach.java.owl) in SADL format"?
-		
-		Build CAL_SOS.
-		CM: "Failed: Unable to find model 'http://sadl.org/SpeedOfSound.sadl#CAL_SOS' in code model".
+			uri "http://sadl.org/SaveTarget.sadl" alias svtgt.
+		'''.sadl
+
+		'''
+			uri "http://sadl.org/CodeExtractionModel.sadl" alias cem.
+			 
+			// This is the code extraction meta-model
+			CodeElement is a class described by beginsAt with a single value of type int,
+				described by endsAt with a single value of type int.
+			
+			CodeBlock is a type of CodeElement,
+				described by serialization with a single value of type string,
+				described by comment with values of type Comment,
+				described by containedIn with values of type CodeBlock.
+			
+			{Class, Method, ConditionalBlock, LoopBlock} are types of CodeBlock.
+			
+			cmArguments describes Method with a single value of type CodeVariable List.
+			cmReturnTypes describes Method with a single value of type string List.
+			cmSemanticReturnTypes describes Method with a single value of type string List.
+			doesComputation describes Method with a single value of type boolean.
+			calls describes Method with values of type MethodCall.
+			ExternalMethod is a type of Method.
+			
+			// The reference to a CodeVariable can be its definition (Defined),
+			//	an assignment or reassignment (Reassigned), or just a reference
+			//	in the right-hand side of an assignment or a conditional (Used)
+			Usage is a class, must be one of {Defined, Used, Reassigned}.
+			
+			Reference  is a type of CodeElement
+				described by firstRef with a single value of type boolean
+				described by codeBlock with a single value of type CodeBlock
+				described by usage with values of type Usage
+					described by input (note "CodeVariable is an input to codeBlock CodeBlock")
+						with a single value of type boolean
+					described by output (note "CodeVariable is an output of codeBlock CodeBlock")
+						with a single value of type boolean
+					described by isImplicit (note "the input or output of this reference is implicit (inferred), not explicit")
+						with a single value of type boolean
+					described by setterArgument (note "is this variable input to a setter?") with a single value of type boolean
+					described by comment with values of type Comment.
+				
+			MethodCall is a type of CodeElement
+				described by codeBlock with a single value of type CodeBlock
+				described by inputMapping with values of type InputMapping,
+				described by returnedMapping with values of type OutputMapping.
+			MethodCallMapping is a class,
+				described by callingVariable with a single value of type CodeVariable,
+				described by calledVariable with a single value of type CodeVariable.
+			{InputMapping, OutputMapping} are types of MethodCallMapping.
+			
+			Comment (note "CodeBlock and Reference can have a Comment") is a type of CodeElement
+			 	described by commentContent with a single value of type string.	
+			
+			// what about Constant also? Note something maybe an input and then gets reassigned
+			// Constant could be defined in terms of being set by equations that only involve Constants
+			// Constants could also relate variables used in different equations as being same
+			CodeVariable  is a type of CodeElement, 
+				described by varName with a single value of type string,
+				described by varType with a single value of type string,
+				described by semanticVarType with a single value of type string,
+				described by quantityKind (note "this should be qudt:QuantityKind") with a single value of type ScientificConcept,
+				described by reference with values of type Reference.
+			
+			{ClassField, MethodArgument, MethodVariable} are types of CodeVariable.
+			
+			//External findFirstLocation (CodeVariable cv) returns int: "http://ToBeImplemented".
+			
+			Rule Transitive
+			if inst is a cls and
+			   cls is a type of CodeVariable
+			then inst is a CodeVariable. 
+			
+			Rule SetNotFirstRef1
+			if c is a CodeVariable and
+			   ref is reference of c and
+			   oneOf(usage of ref, Used, Reassigned) and
+			   ref2 is reference of c and
+			   ref != ref2 and
+			   cb is codeBlock of ref and
+			   cb2 is codeBlock of ref2 and
+			   cb = cb2 and
+			   l1 is beginsAt of ref and
+			   l2 is beginsAt of ref2 and
+			   l2 > l1   // so ref2 is at an earlier location that ref
+			then firstRef of ref2 is false.
+			
+			// first reference is of type "Used" or all earlier refs are of type "Used"
+			// this does not cover when no ref2 with l2 < l1 exists
+			Rule SetAsInput1
+			if c is CodeVariable and
+			   ref is reference of c and
+			   input of ref is not known and
+			   usage of ref is Used and
+			   ref2 is reference of c and
+			   ref != ref2 and
+			   cb is codeBlock of ref and
+			   cb2 is codeBlock of ref2 and
+			   cb = cb2 and   
+			   l1 is beginsAt of ref and
+			   l2 is beginsAt of ref2 and
+			   l2 < l1 and  // so ref2 is at an earlier location that ref
+			   noValue(ref2, usage, Reassigned) // no earlier reassignment of c exists
+			then input of ref is true and isImplicit of ref is true. 
+			
+			// if there is no l2 as specified in the previous rules, then the following covers that case
+			// do I need to consider codeBlock?????
+			Rule SetAsInput2
+			if c is a CodeVariable and
+			   ref is reference of c and
+			   input of ref is not known and
+			   usage of ref is Used and 
+			   noValue(ref, firstRef)
+			then input of ref is true and isImplicit of ref is true.
+			
+			// "it is an output if it is computed and is argument to a setter"
+			// or I could try to use the notion of a constant
+			Rule SetAsOutput
+			if c is a CodeVariable and
+			   setterArgument of c is true and
+			   ref is a reference of c and
+			   output of ref is not known and
+			   usage of ref is Defined //check this?
+			then
+				output of ref is true and isImplicit of ref is true.
+		'''.sadl
+
+		'''
+			uri "http://darpa/aske/ge/ta1/testdlg" alias tdlg.
+			
+			import "http://sadl.org/Model.sadl".
+			
+			target model "http://sadl.org/SaveTarget.sadl" alias tgt.
+			
+			MyHulk is a Mass with ^value 280, with unit "lbs".
+			
+			Ask unit of MyHulk?
+			
+			What is acceleration?
+			
+			What is the force of some Mass when the acceleration of the Mass is 25?
+			
+			What type of values can acceleration of Mass have?
+			
+			How many values of acceleration of type Acceleration can a Mass have?
+			
+			Save secondLaw to sos.
+			
+			evaluate secondLaw(10, 25).
+			
+			yes.
+			
+			My name is Andy.
+			
+			External Mach.CAL_GAM(double T, double G, double Q) returns double: "http://com.ge.research.sadl.darpa.aske.answer/Mach_java#Mach.CAL_GAM".
+			
+			Equation plusOne(int i) returns int: i+1.
+			
+			Evaluate plusOne(10).
 		'''.assertValidatesTo [ ontModel, issues, processor |
 			assertNotNull(ontModel)
 			assertTrue(issues.filter[severity === Severity.ERROR].empty)
 		]
 	}
-	
+
 }

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/DialogProcessorContextPreferenceValuesProvider.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/DialogProcessorContextPreferenceValuesProvider.xtend
@@ -1,23 +1,43 @@
 package com.ge.research.sadl.darpa.aske.processing
 
+import com.ge.research.sadl.preferences.SadlPreferences
 import com.ge.research.sadl.processing.IModelProcessor.ProcessorContextPreferenceValuesProvider
 import java.util.List
+import org.eclipse.emf.common.EMFPlugin
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.preferences.IPreferenceValues
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues
 import org.eclipse.xtext.preferences.PreferenceKey
+import org.eclipse.xtext.preferences.PreferenceValuesByLanguage
 import org.eclipse.xtext.resource.XtextResource
 
 class DialogProcessorContextPreferenceValuesProvider extends ProcessorContextPreferenceValuesProvider {
+	
+	static val SADL_LANGUAGE_ID = 'com.ge.research.sadl.SADL'
 
 	override getPreferenceValues(Resource resource) {
-		if (resource.URI.toString.endsWith('.dialog')) {
-			// https://github.com/GEGlobalResearch/DARPA-ASKE-TA1/issues/24
-			// This is workaround.
-			// We want to use the SADL preferences in the SADL model processor although we have a `.dialog` resource.
+		// https://github.com/GEGlobalResearch/DARPA-ASKE-TA1/issues/24
+		// This is workaround.
+		// We want to use the SADL preferences in the SADL model processor although we have a `.dialog` resource.
+		val IPreferenceValues sadlPreferenceValues = if (EMFPlugin.IS_ECLIPSE_RUNNING) {
 			val dummySadlResource = new XtextResource(URI.createFileURI('dummy.sadl'))
-			val sadlPreferenceValues = preferenceProvider.getPreferenceValues(dummySadlResource)
+			preferenceProvider.getPreferenceValues(dummySadlResource)
+		} else {
+			val existingPreferenceValues = PreferenceValuesByLanguage.findInEmfObject(resource.resourceSet)
+			if (existingPreferenceValues !== null && existingPreferenceValues.get(SADL_LANGUAGE_ID) !== null) {
+				existingPreferenceValues.get(SADL_LANGUAGE_ID)
+			} else {
+				val sadlPreferences = SadlPreferences.preferences.toMap([id], [defaultValue]);
+				val preferenceValues = new MapBasedPreferenceValues(sadlPreferences);
+				val referenceValuesByLanguage = new PreferenceValuesByLanguage;
+				referenceValuesByLanguage.put(SADL_LANGUAGE_ID, preferenceValues);
+				referenceValuesByLanguage.attachToEmfObject(resource.resourceSet);
+				preferenceValues
+			}
+		}
+		if (resource.URI.toString.endsWith('.dialog')) {
 			if (sadlPreferenceValues !== null) {
 				val dialogPreferenceValues = preferenceProvider.getPreferenceValues(resource)
 				return new CompositePreferenceValues(#[sadlPreferenceValues, dialogPreferenceValues])

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/JenaBasedDialogModelProcessor.java
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/JenaBasedDialogModelProcessor.java
@@ -632,7 +632,7 @@ public class JenaBasedDialogModelProcessor extends JenaBasedSadlModelProcessor {
 		boolean returnVal = true;
 		String uri = element.getUri();
 		String prefix = element.getPrefix();
-		String altUrl = getConfigMgr().getAltUrlFromPublicUri(uri);
+		String altUrl = getConfigMgr().getJenaDocumentMgr() != null ? getConfigMgr().getAltUrlFromPublicUri(uri) : null;
 		if (altUrl == null || altUrl.equals(uri)) {
 			addError("Model not found", element);
 			returnVal = false;

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/JenaBasedDialogModelProcessor.java
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/JenaBasedDialogModelProcessor.java
@@ -298,7 +298,7 @@ public class JenaBasedDialogModelProcessor extends JenaBasedSadlModelProcessor {
 		try {
 			if (!getAnswerCurationManager().dialogAnserProviderInitialized()) {
 				System.out.println("DialogAnswerProvider not yet initialized. Touch window.");
-				return;
+//				return;
 			}
 		} catch (IOException e2) {
 			// TODO Auto-generated catch block


### PR DESCRIPTION
@crapo, I have updated the test for dialogs. Please note, I did the following changes in the dialog model processor:
 - Do not `return` from `onValidate` if the answer-provider is not initialized,
 - Do not try to map the model URI to an alternative URL if the Jena document manager is `null`, which is always the case for the headless tests.

Still, it fails with an NPE here because the target mapping is `null`:
https://github.com/GEGlobalResearch/DARPA-ASKE-TA1/blob/5159a7104124406b0f27015dcc91d6a05c19e2c5/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/JenaBasedDialogModelProcessor.java#L923

