### PR TITLE
GH-32: Added CA support for `target model`.

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ide/src/com/ge/research/sadl/darpa/aske/ide/editor/contentassist/DialogIdeContentProposalProvider.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ide/src/com/ge/research/sadl/darpa/aske/ide/editor/contentassist/DialogIdeContentProposalProvider.xtend
@@ -1,7 +1,33 @@
 package com.ge.research.sadl.darpa.aske.ide.editor.contentassist
 
+import com.ge.research.sadl.darpa.aske.services.DialogGrammarAccess
 import com.ge.research.sadl.ide.editor.contentassist.SadlIdeContentProposalProvider
+import com.google.inject.Inject
+import org.eclipse.xtext.Assignment
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor
 
 class DialogIdeContentProposalProvider extends SadlIdeContentProposalProvider {
-	
+
+	@Inject
+	DialogGrammarAccess grammarAccess;
+
+	override protected _createProposals(Assignment assignment, ContentAssistContext ctx,
+		IIdeContentProposalAcceptor acceptor) {
+
+		if(excludedNamespaces !== null) excludedNamespaces.clear
+		if(typeRestrictions !== null) typeRestrictions.clear
+		switch (assignment) {
+			case grammarAccess.targetModelNameAccess.targetResourceAssignment_2: {
+				ctx.completeImports(acceptor);
+			}
+			case grammarAccess.targetModelNameAccess.aliasAssignment_3_1: {
+				ctx.completeAlias(acceptor);
+			}
+			default: {
+				super._createProposals(assignment, ctx, acceptor);
+			}
+		}
+	}
+
 }

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ide/src/com/ge/research/sadl/darpa/aske/ide/editor/contentassist/DialogIdeCrossrefProposalProvider.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ide/src/com/ge/research/sadl/darpa/aske/ide/editor/contentassist/DialogIdeCrossrefProposalProvider.xtend
@@ -1,7 +1,30 @@
 package com.ge.research.sadl.darpa.aske.ide.editor.contentassist
 
 import com.ge.research.sadl.ide.editor.contentassist.SadlIdeCrossrefProposalProvider
+import org.eclipse.xtext.CrossReference
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext
+import org.eclipse.xtext.resource.IEObjectDescription
+
+import static com.ge.research.sadl.darpa.aske.dialog.DialogPackage.Literals.*
+import static com.ge.research.sadl.sADL.SADLPackage.Literals.*
 
 class DialogIdeCrossrefProposalProvider extends SadlIdeCrossrefProposalProvider {
-	
+
+	override protected createProposal(IEObjectDescription candidate, CrossReference crossRef,
+		ContentAssistContext context) {
+
+		// Need to escape the import with double quotes.
+		if (SADL_MODEL == candidate.EClass && SADL_MODEL == crossRef?.type.classifier &&
+			TARGET_MODEL_NAME == context?.currentModel.eClass) {
+
+			val proposal = '''"«qualifiedNameConverter.toString(candidate.name)»"''';
+			return proposalCreator.createProposal(proposal, context) [
+				source = candidate
+				description = candidate.getEClass?.name
+			];
+
+		} else {
+			super.createProposal(candidate, crossRef, context)
+		}
+	}
 }


### PR DESCRIPTION

![screencast 2019-09-19 13-43-45](https://user-images.githubusercontent.com/1405703/65241495-f0915b00-dae3-11e9-8f73-f382e66f5d41.gif)
Closes #32.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>