### PR TITLE
Eval grammar vol2

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogLexerTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogLexerTest.xtend
@@ -1,0 +1,91 @@
+package com.ge.research.sadl.darpa.aske.tests
+
+import com.ge.research.sadl.darpa.aske.parser.antlr.lexer.InternalDialogLexer
+import com.google.inject.Inject
+import com.google.inject.Provider
+import org.antlr.runtime.ANTLRStringStream
+import org.antlr.runtime.Token
+import org.eclipse.xtext.parser.antlr.Lexer
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static java.lang.System.lineSeparator
+import static com.ge.research.sadl.darpa.aske.parser.antlr.internal.InternalDialogParser.*
+import static org.junit.Assert.assertEquals
+
+@RunWith(XtextRunner)
+@InjectWith(DialogInjectorProvider)
+class DialogLexerTest {
+
+	@Inject
+	Provider<InternalDialogLexer> lexer
+
+	@Test
+	def void eval_0_params() {
+		val it = '''
+			uri "http://test".
+			Evaluate CAL_SOS().
+		'''.createLexer
+		assertNextToken(Uri, 'uri')
+		assertNextToken(RULE_WS, ' ')
+		assertNextToken(RULE_STRING, '"http://test"')
+		assertNextToken(FullStop, '.')
+		assertNextToken(RULE_WS, lineSeparator)
+		assertNextToken(Evaluate, 'Evaluate')
+		assertNextToken(RULE_WS, ' ')
+		assertNextToken(RULE_ID, 'CAL_SOS')
+		assertNextToken(LeftParenthesis, '(')
+		assertNextToken(RightParenthesis, ')')
+		assertNextToken(FullStop, '.')
+		assertNextToken(RULE_WS, lineSeparator)
+		nextToken.assertEndOfTokens
+	}
+
+	@Test
+	def void eval_2_params() {
+		val it = '''
+			uri "http://test".
+			Evaluate CAL_SOS(1, 2).
+		'''.createLexer
+		assertNextToken(Uri, 'uri')
+		assertNextToken(RULE_WS, ' ')
+		assertNextToken(RULE_STRING, '"http://test"')
+		assertNextToken(FullStop, '.')
+		assertNextToken(RULE_WS, lineSeparator)
+		assertNextToken(Evaluate, 'Evaluate')
+		assertNextToken(RULE_WS, ' ')
+		assertNextToken(RULE_ID, 'CAL_SOS')
+		assertNextToken(LeftParenthesis, '(')
+		assertNextToken(RULE_NUMBER, '1')
+		assertNextToken(Comma, ',')
+		assertNextToken(RULE_WS, ' ')
+		assertNextToken(RULE_NUMBER, '2')
+		assertNextToken(RightParenthesis, ')')
+		assertNextToken(FullStop, '.')
+		assertNextToken(RULE_WS, lineSeparator)
+		nextToken.assertEndOfTokens
+	}
+
+	private def createLexer(CharSequence cs) {
+		return lexer.get => [
+			charStream = new ANTLRStringStream(cs.toString)
+		]
+	}
+
+	private def assertEndOfTokens(Token token) {
+		token.assertEquals(-1, null)
+	}
+
+	private def void assertNextToken(Lexer it, int id, String text) {
+		nextToken.assertEquals(id, text)
+	}
+
+	private def void assertEquals(Token token, int id, String text) {
+		assertEquals('''Expected token text was: «text», actual was: «token.text»''', id, token.type)
+		if (text !== null) {
+			assertEquals('''Expected token was: «id»''', text, token.text)
+		}
+	}
+}

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogParsingTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogParsingTest.xtend
@@ -39,6 +39,14 @@ class DialogParsingTest {
 			Evaluate CAL_SOS(1, 2).
 		'''.assertNoErrors
 	}
+	
+	@Test
+	def void evalStatement_2_paramsWithUnit() {
+		'''
+			uri "http://test".
+			Evaluate CAL_SOS(1 { "cm" }, 2).
+		'''.assertNoErrors
+	}
 
 	private def assertNoErrors(CharSequence s) {
 		val model = s.parse

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogParsingTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/src/com/ge/research/sadl/darpa/aske/tests/DialogParsingTest.xtend
@@ -1,39 +1,3 @@
-/********************************************************************** 
- * Note: This license has also been called the "New BSD License" or 
- * "Modified BSD License". See also the 2-clause BSD License.
- *
- * Copyright © 2018-2019 - General Electric Company, All Rights Reserved
- * 
- * Project: ANSWER, developed with the support of the Defense Advanced 
- * Research Projects Agency (DARPA) under Agreement  No.  HR00111990006. 
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met:
- * 1. Redistributions of source code must retain the above copyright notice, 
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its 
- *    contributors may be used to endorse or promote products derived 
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- *
- ***********************************************************************/
-
 package com.ge.research.sadl.darpa.aske.tests
 
 import com.ge.research.sadl.sADL.SadlModel
@@ -42,24 +6,45 @@ import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.util.ParseHelper
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(XtextRunner)
 @InjectWith(DialogInjectorProvider)
 class DialogParsingTest {
-	@Inject
-	ParseHelper<SadlModel> parseHelper
 
-	@Ignore
+	@Inject
+	extension ParseHelper<SadlModel> parseHelper
+
 	@Test
-	def void loadModel() {
-		val result = parseHelper.parse('''
-			Hello Xtext!
-		''')
-		Assert.assertNotNull(result)
-		val errors = result.eResource.errors
-//		Assert.assertTrue('''Unexpected errors: «errors.join(", ")»''', errors.isEmpty)
+	def void evalStatement_0_params() {
+		'''
+			uri "http://test".
+			Evaluate CAL_SOS().
+		'''.assertNoErrors
 	}
+
+	@Test
+	def void evalStatement_1_params() {
+		'''
+			uri "http://test".
+			Evaluate CAL_SOS(1).
+		'''.assertNoErrors
+	}
+
+	@Test
+	def void evalStatement_2_params() {
+		'''
+			uri "http://test".
+			Evaluate CAL_SOS(1, 2).
+		'''.assertNoErrors
+	}
+
+	private def assertNoErrors(CharSequence s) {
+		val model = s.parse
+		Assert.assertNotNull(model)
+		val errors = model.eResource.errors
+		Assert.assertTrue('''Unexpected errors: «errors.join(", ")»''', errors.isEmpty)
+	}
+
 }

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/model/generated/Dialog.ecore
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/model/generated/Dialog.ecore
@@ -23,9 +23,11 @@
   <eClassifiers xsi:type="ecore:EClass" name="SadlEquationInvocation" eSuperTypes="platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlModelElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="name" eType="ecore:EClass platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlResource"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1"
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
         eType="ecore:EClass platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//Expression"
         containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="units" unique="false" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TargetModelName" eSuperTypes="platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlModelElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="targetResource" eType="ecore:EClass platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlModel"/>

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/model/generated/Dialog.ecore
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/model/generated/Dialog.ecore
@@ -23,11 +23,9 @@
   <eClassifiers xsi:type="ecore:EClass" name="SadlEquationInvocation" eSuperTypes="platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlModelElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="name" eType="ecore:EClass platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlResource"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" upperBound="-1"
+    <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1"
         eType="ecore:EClass platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//Expression"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="units" unique="false" upperBound="-1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TargetModelName" eSuperTypes="platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlModelElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="targetResource" eType="ecore:EClass platform:/resource/com.ge.research.sadl/model/generated/SADL.ecore#//SadlModel"/>

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/Dialog.xtext
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/Dialog.xtext
@@ -81,7 +81,7 @@ ExtractStatement:
 ;
 
 EvalStatement returns SadlEquationInvocation:
-	{SadlEquationInvocation} ('Evaluate'|'evaluate') name=SadlResource '(' (parameter+=Expression ('{'units+=UNIT'}')? (',' parameter+=Expression ('{'units+=UNIT'}')?)* )?')'
+	{SadlEquationInvocation} ('Evaluate'|'evaluate') name=SadlResource '(' (parameters+=UnitExpression<true, true> (',' parameters+=UnitExpression<true, true>)* )?')'
 ;
 
 TargetModelName:

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/Dialog.xtext
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/Dialog.xtext
@@ -81,7 +81,7 @@ ExtractStatement:
 ;
 
 EvalStatement returns SadlEquationInvocation:
-	{SadlEquationInvocation} ('Evaluate'|'evaluate') name=SadlResource '(' (parameters+=UnitExpression<true, true> (',' parameters+=UnitExpression<true, true>)* )?')'
+	{SadlEquationInvocation} ('Evaluate'|'evaluate') name=SadlResource '(' (parameter+=ExpressionParameterized<false,true> ('{'units+=UNIT'}')? (',' parameter+=ExpressionParameterized<false,true> ('{'units+=UNIT'}')?)* )?')'
 ;
 
 TargetModelName:


### PR DESCRIPTION
@crapo, here is another alternative for the eval statements, it follows your initial grammar where the `SadlEquationInvocation` has its dedicated `expressions` and `units` `ECollection`.

So you can write:
```java
uri "http://test".
Evaluate CAL_SOS(1 { "cm" }, 2).
```

as opposed to the following I have suggested in #60
```java
uri "http://test".
Evaluate CAL_SOS(1 "cm", 2).
```