### PR TITLE
GH-58: Use `Dialog` specific injection for the `Dialog` tests.

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui.tests/src/com/ge/research/sadl/darpa/aske/dialog/ui/tests/AbstractDialogPlatformTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui.tests/src/com/ge/research/sadl/darpa/aske/dialog/ui/tests/AbstractDialogPlatformTest.xtend
@@ -1,30 +1,33 @@
 package com.ge.research.sadl.darpa.aske.dialog.ui.tests
 
+import com.ge.research.sadl.darpa.aske.ui.tests.DialogUiInjectorProvider
+import com.ge.research.sadl.jena.IJenaBasedModelProcessor
+import com.ge.research.sadl.model.gp.Rule
+import com.ge.research.sadl.model.gp.SadlCommand
+import com.ge.research.sadl.tests.SadlTestAssertions
+import com.ge.research.sadl.ui.tests.AbstractSadlPlatformTest
 import com.hp.hpl.jena.ontology.OntModel
 import java.util.List
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.validation.Issue
-import com.ge.research.sadl.ui.tests.AbstractSadlPlatformTest
-import com.ge.research.sadl.model.gp.SadlCommand
-import com.ge.research.sadl.model.gp.Rule
-import com.ge.research.sadl.jena.IJenaBasedModelProcessor
-import com.ge.research.sadl.tests.SadlTestAssertions
-import com.ge.research.sadl.darpa.aske.tests.AbstractDialogTest
+import org.junit.runner.RunWith
 
+@RunWith(XtextRunner)
+@InjectWith(DialogUiInjectorProvider)
 abstract class AbstractDialogPlatformTest extends AbstractSadlPlatformTest {
-	
-	
+
 	protected def Resource assertValidatesDialogTo(Resource resource,
 		(OntModel, List<Rule>, List<SadlCommand>, List<Issue>, IJenaBasedModelProcessor)=>void assertions) {
 
 		return SadlTestAssertions.assertValidatesTo(resource as XtextResource, assertions);
 	}
-	
+
 	protected def Resource assertValidatesDialogTo(Resource resource, boolean rawResults, boolean treatAsConclusion,
 		(OntModel, List<Object>, List<SadlCommand>, List<Issue>, IJenaBasedModelProcessor)=>void assertions) {
-			
 //			return AbstractDialogTest.assertValidatesTo(resource as XtextResource, assertions); 
-		}
+	}
 
 }


### PR DESCRIPTION
Added the missing injector provider. Without the explicit provider, it
will inject SADL specific things into the test, instead of the desired
`Dialog`.

Closes #58.

With the changes, I can see in the `c.g.r.s.d.aske.processing.JenaBasedDialogModelProcessor.initializePreferences(ProcessorContext)`:
https://github.com/GEGlobalResearch/DARPA-ASKE-TA1/blob/9b153b88913ccd40505a1175082a9dcb853c6517/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog/src/com/ge/research/sadl/darpa/aske/processing/JenaBasedDialogModelProcessor.java#L1967-L1970

That the base text service URL is `http://vesuvius-dev.crd.ge.com:4200` instead of the default `http://localhost:4200`.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>