### PR TITLE
GH-59: Run the headless tests without OSGi

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/pom.xml
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.tests/pom.xml
@@ -12,6 +12,12 @@
 	<name>DARPA-ASKE Tests</name>
 
 	<build>
+		<!-- We do not want to run the headless tests in an OSGi container. -->
+		<!-- We use Maven Surefire instead of Tycho Surefire to run the tests outside of the OSGi container. -->
+		<!-- Source: https://wiki.eclipse.org/Tycho/FAQ#Can_I_run_eclipse-plugin_tests_also_outside_an_OSGi_container.3F -->
+		<!-- GH issue: https://github.com/GEGlobalResearch/DARPA-ASKE-TA1/issues/59 -->
+		<!-- Maven Surefire expects test classes in ${project.build.directory}/test-classes by default. -->
+		<testOutputDirectory>${project.build.directory}/classes</testOutputDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
@@ -59,6 +65,28 @@
 				<configuration>
 					<compilerArgument>-err:-forbidden</compilerArgument>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20.1</version>
+				<dependencies>
+					<!-- Explicitly declare the Maven Surefire provider for JUnit4, see http://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html -->
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit4</artifactId>
+						<version>2.20.1</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Closes #59.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

I could not run all the tests, but I can see, that the problematic `BasicMissingPatternsInCompareTest` test has passed with my changes from a Maven build. (See the very last line of the console output 👇)

```
[INFO] Running com.ge.research.sadl.darpa.aske.tests.BasicMissingPatternsInCompareTest
Rule R1:  if is(mdl:sfc,0.35) then is(mdl:thrust,2000).
Can't find property 'http://aske.ge.com/metamodel#CGQuery'. Something is wrong.
com.ge.research.sadl.processing.SadlInferenceException: Inference execution failed for prefix cg:<http://aske.ge.com/compgraphmodel#>
prefix imp:<http://sadl.org/sadlimplicitmodel#>
prefix sci:<http://aske.ge.com/sciknow#>
prefix list:<http://sadl.org/sadllistmodel#>
prefix rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>

insert 
{ ?Eq imp:genericInput ?In. ?Eq imp:genericOutput ?Out. }
where {
  
 {?Eq imp:returnTypes ?AL1.
  ?AL1 list:rest*/list:first ?AO1.
  ?AO1 imp:augmentedType ?Type1.
  ?Type1 imp:constraints ?CL1.
  ?CL1 rdf:rest*/rdf:first ?C1.
  ?C1 imp:gpPredicate ?P.
  ?P rdfs:range ?Out. }

  union {
    ?Eq imp:implicitOutput/imp:augmentedType/imp:semType ?Out.
    filter not exists{?Eq a imp:IntializerMethod} }

  union{
   ?Eq imp:arguments ?AL2.
   ?AL2 list:rest*/list:first ?AO2.
   ?AO2 imp:augmentedType ?Type2.
   ?Type2 imp:constraints ?CL2.
   ?CL2 rdf:rest*/rdf:first ?C2.
   ?C2 imp:gpPredicate ?P.
   ?P rdfs:range ?In.}

  union { #Explicit inputs w/o AT
    ?Eq imp:arguments ?AL2.
    ?AL2 list:rest*/list:first ?AO2.
    filter not exists {?AO2 imp:augmentedType []}
    ?AO2 imp:localDescriptorName ?In.}

  union {?Eq imp:implicitInput/imp:augmentedType/imp:semType ?In.
   filter not exists{?Eq a imp:IntializerMethod} }

  union {
   ?Eq imp:implicitOutput/imp:localDescriptorName ?Out.
   filter not exists{?Eq a imp:IntializerMethod} }
  union {
   ?Eq imp:implicitInput?IO.
   filter not exists {?IO imp:augmentedType [] }
   ?IO imp:localDescriptorName ?In.
   filter not exists{?Eq a imp:IntializerMethod} } 
}
	at com.ge.research.sadl.darpa.aske.inference.JenaBasedDialogInferenceProcessor.insertRulesAndQuery(JenaBasedDialogInferenceProcessor.java:797)
	at com.ge.research.sadl.darpa.aske.curation.AnswerCurationManager.insertRulesAndQuery(AnswerCurationManager.java:3646)
	at com.ge.research.sadl.darpa.aske.curation.AnswerCurationManager.processCompareRequest(AnswerCurationManager.java:2664)
	at com.ge.research.sadl.darpa.aske.curation.AnswerCurationManager.processUserRequest(AnswerCurationManager.java:2651)
	at com.ge.research.sadl.darpa.aske.curation.AnswerCurationManager.processConversation(AnswerCurationManager.java:3812)
	at com.ge.research.sadl.darpa.aske.processing.JenaBasedDialogModelProcessor.onValidate(JenaBasedDialogModelProcessor.java:463)
	at com.ge.research.sadl.validation.ResourceValidator.doValidate(ResourceValidator.java:75)
	at com.ge.research.sadl.validation.ResourceValidator.validate(ResourceValidator.java:71)
	at org.eclipse.xtext.validation.ResourceValidatorImpl.validate(ResourceValidatorImpl.java:90)
	at com.ge.research.sadl.validation.ResourceValidator.lambda$0(ResourceValidator.java:55)
	at org.eclipse.xtext.util.OnChangeEvictingCache.get(OnChangeEvictingCache.java:76)
	at com.ge.research.sadl.validation.ResourceValidator.validate(ResourceValidator.java:57)
	at com.ge.research.sadl.tests.SadlTestAssertions.assertValidatesTo(SadlTestAssertions.java:55)
	at com.ge.research.sadl.darpa.aske.tests.AbstractDialogTest.assertValidatesTo(AbstractDialogTest.java:42)
	at com.ge.research.sadl.darpa.aske.tests.BasicMissingPatternsInCompareTest.test(BasicMissingPatternsInCompareTest.java:65)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.eclipse.xtext.testing.XtextRunner$1.evaluate(XtextRunner.java:49)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:369)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:275)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:239)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:160)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:373)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:334)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:119)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:407)
Caused by: com.ge.research.sadl.processing.SadlInferenceException: Inference execution failed for prefix cg:<http://aske.ge.com/compgraphmodel#>
prefix imp:<http://sadl.org/sadlimplicitmodel#>
prefix sci:<http://aske.ge.com/sciknow#>
prefix list:<http://sadl.org/sadllistmodel#>
prefix rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
prefix rdfs:<http://www.w3.org/2000/01/rdf-schema#>

insert 
{ ?Eq imp:genericInput ?In. ?Eq imp:genericOutput ?Out. }
where {
  
 {?Eq imp:returnTypes ?AL1.
  ?AL1 list:rest*/list:first ?AO1.
  ?AO1 imp:augmentedType ?Type1.
  ?Type1 imp:constraints ?CL1.
  ?CL1 rdf:rest*/rdf:first ?C1.
  ?C1 imp:gpPredicate ?P.
  ?P rdfs:range ?Out. }

  union {
    ?Eq imp:implicitOutput/imp:augmentedType/imp:semType ?Out.
    filter not exists{?Eq a imp:IntializerMethod} }

  union{
   ?Eq imp:arguments ?AL2.
   ?AL2 list:rest*/list:first ?AO2.
   ?AO2 imp:augmentedType ?Type2.
   ?Type2 imp:constraints ?CL2.
   ?CL2 rdf:rest*/rdf:first ?C2.
   ?C2 imp:gpPredicate ?P.
   ?P rdfs:range ?In.}

  union { #Explicit inputs w/o AT
    ?Eq imp:arguments ?AL2.
    ?AL2 list:rest*/list:first ?AO2.
    filter not exists {?AO2 imp:augmentedType []}
    ?AO2 imp:localDescriptorName ?In.}

  union {?Eq imp:implicitInput/imp:augmentedType/imp:semType ?In.
   filter not exists{?Eq a imp:IntializerMethod} }

  union {
   ?Eq imp:implicitOutput/imp:localDescriptorName ?Out.
   filter not exists{?Eq a imp:IntializerMethod} }
  union {
   ?Eq imp:implicitInput?IO.
   filter not exists {?IO imp:augmentedType [] }
   ?IO imp:localDescriptorName ?In.
   filter not exists{?Eq a imp:IntializerMethod} } 
}
	at com.ge.research.sadl.darpa.aske.inference.JenaBasedDialogInferenceProcessor.runInference(JenaBasedDialogInferenceProcessor.java:1571)
	at com.ge.research.sadl.darpa.aske.inference.JenaBasedDialogInferenceProcessor.processSingleWhatWhenQuery(JenaBasedDialogInferenceProcessor.java:1043)
	at com.ge.research.sadl.darpa.aske.inference.JenaBasedDialogInferenceProcessor.insertTriplesAndQuery(JenaBasedDialogInferenceProcessor.java:895)
	at com.ge.research.sadl.darpa.aske.inference.JenaBasedDialogInferenceProcessor.insertRulesAndQuery(JenaBasedDialogInferenceProcessor.java:794)
	... 41 more
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.586 s - in com.ge.research.sadl.darpa.aske.tests.BasicMissingPatternsInCompareTest
```