### PR TITLE
GH-75: The dialog platform test can delegate into SADL preference store

### DIFF
--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui.tests/src/com/ge/research/sadl/darpa/aske/dialog/ui/tests/AbstractDialogPlatformTest.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui.tests/src/com/ge/research/sadl/darpa/aske/dialog/ui/tests/AbstractDialogPlatformTest.xtend
@@ -12,8 +12,11 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess
 import org.eclipse.xtext.validation.Issue
 import org.junit.runner.RunWith
+
+import static com.google.common.base.Preconditions.*
 
 @RunWith(XtextRunner)
 @InjectWith(DialogUiInjectorProvider)
@@ -22,12 +25,25 @@ abstract class AbstractDialogPlatformTest extends AbstractSadlPlatformTest {
 	protected def Resource assertValidatesDialogTo(Resource resource,
 		(OntModel, List<Rule>, List<SadlCommand>, List<Issue>, IJenaBasedModelProcessor)=>void assertions) {
 
-		return SadlTestAssertions.assertValidatesTo(resource as XtextResource, assertions);
+		return SadlTestAssertions.assertValidatesTo(resource as XtextResource, assertions)
 	}
 
-	protected def Resource assertValidatesDialogTo(Resource resource, boolean rawResults, boolean treatAsConclusion,
-		(OntModel, List<Object>, List<SadlCommand>, List<Issue>, IJenaBasedModelProcessor)=>void assertions) {
-//			return AbstractDialogTest.assertValidatesTo(resource as XtextResource, assertions); 
+	override protected getPreferenceStore(String preferenceKey) {
+		val store = super.getPreferenceStore(preferenceKey)
+		if (store.contains(preferenceKey)) {
+			return store
+		}
+		// We assume, it is a SADL preference as it was not in the `Dialog`-specific preference store.
+		// We cannot use injection here, as we are in a `Dialog` test so we have to assume, the SADL built-ins are in the project.
+		// We load the of the built-in implicit SADL model and acquire the SADL preference store from the `XtextResource`'s service provider.
+		val resource = ('ImplicitModel/SadlImplicitModel.sadl'.file.resource as XtextResource)
+		val storeAccess = resource.resourceServiceProvider.get(IPreferenceStoreAccess)
+		val sadlStore = checkNotNull(storeAccess.writablePreferenceStore, 'Could not get preference store for SADL.')
+		checkState(
+			sadlStore.contains(preferenceKey),
+			'''Could not find the '«preferenceKey»' preference key in the SADL store.'''
+		)
+		return sadlStore
 	}
 
 }

--- a/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui.tests/src/com/ge/research/sadl/darpa/aske/dialog/ui/tests/P2UITests.xtend
+++ b/com.ge.research.sadl.darpa.aske.dialog.parent/com.ge.research.sadl.darpa.aske.dialog.ui.tests/src/com/ge/research/sadl/darpa/aske/dialog/ui/tests/P2UITests.xtend
@@ -148,6 +148,7 @@ public class P2UITests extends AbstractDialogPlatformTest {
 	def reusableTurbo() {
 		updatePreferences(new PreferenceKey(SadlPreferences.TYPE_CHECKING_WARNING_ONLY.id, Boolean.TRUE.toString));
 		updatePreferences(new PreferenceKey(SadlPreferences.P_USE_ARTICLES_IN_VALIDATION.id, Boolean.FALSE.toString));
+		updatePreferences(new PreferenceKey(SadlPreferences.TYPE_CHECKING_RANGE_REQUIRED.id, Boolean.FALSE.toString));
 		val filepath = getKbRoot + "/Turbo.sadl"
 		val modelcontent = readFile(new File(filepath))
 		createFile("Turbo.sadl", modelcontent).resource.assertValidatesTo[jenaModel, rules, commands, issues, processor |


### PR DESCRIPTION
Closes #75.

Upstream PR: https://github.com/crapo/sadlos2/pull/404

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

@crapo, please note, [I had to set the `TYPE_CHECKING_RANGE_REQUIRED ` preference to `false`](https://github.com/GEGlobalResearch/DARPA-ASKE-TA1/pull/76/files#diff-4efccc0d1b3d948bdc54478d7495ae94R151), now `Turbo.sadl` is also valid. We are down to two validation issues:

```
ERROR:Did not find crule variable for type 'hypersonicsV2:CF6', definite article, ordinal 1 (platform:/resource/P2UITests_test/test4.dialog line : 9 column : 50)
ERROR:Did not find crule variable for type 'hypersonicsV2:CF6', definite article, ordinal 1 (platform:/resource/P2UITests_test/test4.dialog line : 9 column : 89)
```

I think they're unrelated to the way we handle the preferences in the platform tests:

```
java.lang.AssertionError: expected:<0> but was:<2>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at com.ge.research.sadl.darpa.aske.dialog.ui.tests.P2UITests.lambda$0(P2UITests.java:114)
	at com.ge.research.sadl.tests.SadlTestAssertions.assertValidatesTo(SadlTestAssertions.java:66)
	at com.ge.research.sadl.darpa.aske.dialog.ui.tests.AbstractDialogPlatformTest.assertValidatesDialogTo(AbstractDialogPlatformTest.java:28)
	at com.ge.research.sadl.darpa.aske.dialog.ui.tests.P2UITests.test(P2UITests.java:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.pde.internal.junit.runtime.RemotePluginTestRunner.main(RemotePluginTestRunner.java:232)
	at org.eclipse.pde.internal.junit.runtime.PlatformUITestHarness.lambda$0(PlatformUITestHarness.java:45)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4095)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3762)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1173)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1062)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:636)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:563)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:151)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:155)
	at org.eclipse.pde.internal.junit.runtime.NonUIThreadTestApplication.runApp(NonUIThreadTestApplication.java:55)
	at org.eclipse.pde.internal.junit.runtime.UITestApplication.runApp(UITestApplication.java:46)
	at org.eclipse.pde.internal.junit.runtime.NonUIThreadTestApplication.start(NonUIThreadTestApplication.java:49)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:137)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:107)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:400)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:595)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1501)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1474)
```